### PR TITLE
fix npm publish workflow

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -35,6 +35,6 @@ jobs:
         run: pnpm run build
 
       - name: Publish to NPM
-        run: pnpm publish
+        run: pnpm publish --no-git-checks
         env:
           NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}


### PR DESCRIPTION
- MIT License
- Readme file
- fixup! Readme file
- Won't encrypt chrome partial download files (.crdownload files). Removed unnecessary log statement
- Renamed package to @ceicc/autocrypt. Specified files to publish to npm. Explicitly marked package as public.
- Create npm-publish.yml
- fixup! Create npm-publish.yml
